### PR TITLE
[FIX] Fix `ChatRoomActionMessage` for Chinese users

### DIFF
--- a/src/utilsClub.ts
+++ b/src/utilsClub.ts
@@ -111,6 +111,7 @@ export function ChatRoomActionMessage(msg: string, target: null | number = null)
 			{ Tag: "Beep", Text: "msg" },
 			{ Tag: "Biep", Text: "msg" },
 			{ Tag: "Sonner", Text: "msg" },
+			{ Tag: "发送私聊", Text: "msg" },
 			{ Tag: "msg", Text: msg }
 		]
 	});


### PR DESCRIPTION
The change in this commit can prevent Chinese users from seeing bcx messages as "(Beep)", aka "(发送私聊)".