### PR TITLE
Fix vitals curse spam

### DIFF
--- a/src/modules/curses.ts
+++ b/src/modules/curses.ts
@@ -23,7 +23,7 @@ const CURSES_ANTILOOP_RESET_INTERVAL = 60_000;
 const CURSES_ANTILOOP_THRESHOLD = 10;
 const CURSES_ANTILOOP_SUSPEND_TIME = 600_000;
 
-export const CURSE_IGNORED_PROPERTIES = ValidationModifiableProperties.slice();
+export const CURSE_IGNORED_PROPERTIES = ValidationModifiableProperties.concat("HeartRate");
 export const CURSE_IGNORED_EFFECTS = ["Lock"];
 // Ignore slave collars, as they are forced by BC
 const CURSE_IGNORED_ITEMS = ["SlaveCollar", "ClubSlaveCollar"];


### PR DESCRIPTION
Adds HeartRate to the list of properties ignored by curses. Closes #7.