### PR TITLE
[ADD] Add the new `speech_garble_while_talking` rule

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -295,6 +295,7 @@ type BCX_Rule =
 	| "speech_mandatory_words"
 	| "speech_mandatory_words_in_emotes"
 	| "speech_partial_hearing"
+	| "speech_garble_while_talking"
 	| "other_forbid_afk"
 	| "other_track_time"
 	| "other_constant_reminder"
@@ -469,6 +470,9 @@ type RuleCustomData = {
 		randomUnderstanding: boolean;
 		affectGaggedMembersToggle: boolean;
 	},
+	speech_garble_while_talking: {
+		gagLevel: number;
+	}
 	other_forbid_afk: {
 		minutesBeforeAfk: number;
 	},

--- a/src/rules/speech_control.ts
+++ b/src/rules/speech_control.ts
@@ -1178,4 +1178,36 @@ export function initRules_bc_speech_control() {
 			}, ModuleCategory.Rules);
 		}
 	});
+
+	registerRule("speech_garble_while_talking", {
+		name: "Force garbled speech",
+		type: RuleType.Speech,
+		loggable: false,
+		shortDescription: "force PLAYER_NAME to talk as if they were gagged",
+		longDescription: "This rule forces PLAYER_NAME to talk as if they were gagged, automatically garbling all of their speech. This rule does not affect OOC or, if \"Garble whispers while gagged\" is disabled, whispers.",
+		keywords: ["garble", "saying", "talking"],
+		defaultLimit: ConditionsLimit.normal,
+		dataDefinition: {
+			gagLevel: {
+				type: "number",
+				default: 5,
+				options: {
+					min: 1,
+					max: 25
+				},
+				description: "The level of forced garbling"
+			}
+		},
+		load(state) {
+			hookFunction("SpeechGetTotalGagLevel", 0, (args, next) => {
+				const gagLevel: number = next(args);
+				if (!state.isEnforced || !state.customData?.gagLevel || !(args[0] as Character).IsPlayer()) {
+					return gagLevel;
+				} else {
+					// Use the rule-specified gag level as a lower bound in case the player is wearing an actual gag
+					return Math.max(gagLevel, state.customData.gagLevel);
+				}
+			}, ModuleCategory.Rules);
+		}
+	});
 }

--- a/src/rules/speech_control.ts
+++ b/src/rules/speech_control.ts
@@ -1184,13 +1184,17 @@ export function initRules_bc_speech_control() {
 		type: RuleType.Speech,
 		loggable: false,
 		shortDescription: "force PLAYER_NAME to talk as if they were gagged",
-		longDescription: "This rule forces PLAYER_NAME to talk as if they were gagged, automatically garbling all of their speech. This rule does not affect OOC or, if \"Garble whispers while gagged\" is disabled, whispers.",
-		keywords: ["garble", "saying", "talking"],
+		longDescription: `This rule forces PLAYER_NAME to talk as if they were gagged, automatically garbling all of their speech. This rule does not affect OOC. This rule only affects whispers if the rule "Garble whispers while gagged" is also in effect.`,
+		keywords: ["saying", "talking", "gagtalk", "garbling", "forced"],
 		defaultLimit: ConditionsLimit.normal,
 		dataDefinition: {
 			gagLevel: {
 				type: "number",
 				default: 5,
+				/**
+				 * NOTE: While gag levels above 20 do not have any additional effects in vanilla BC,
+				 * FBC's "Extra gag anti-cheat" option (as of 4.22) adds additional garbling at >24.
+				 */
 				options: {
 					min: 1,
 					max: 25


### PR DESCRIPTION
Xref the previous discussion on the BC Scripting Community discord: https://discord.com/channels/842082194209112074/884526083565838367/1083555398637863003

This PR adds the new `Force garbled speech` rule, which forces the affected player to talk as if they were gagged, automatically garbling all of their speech at a specified gagging level (the default of 5 being equivalent to your basic ball gag). This rule does not affect OOC or, if "Garble whispers while gagged" is disabled, whispers.

Two things of note:
* The required `SpeechGetTotalGagLevel()` hook is reliant on changes introduces in BC R90, which consolidated the usage of aforementioned function such that it is the only function that requires hooking in to (xref https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/3951). 
* ~~Two `TMP` commits are included for now as I needed them for actually testing the changes; they should not be merged x)~~