### PR TITLE
[CHORE] Update pose-specific function names

### DIFF
--- a/src/commands/command_definitions.ts
+++ b/src/commands/command_definitions.ts
@@ -188,7 +188,7 @@ export function initCommands_definitions() {
 				respond(`You cannot change into this pose as the rule '${ruleState.ruleDefinition.name}' forbids it.`);
 				return false;
 			}
-			CharacterSetActivePose(Player, pose);
+			PoseSetActive(Player, pose);
 			ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
 			if (!sender.isPlayer()) {
 				const text = armsTexts[argv[0].toLowerCase()];
@@ -241,7 +241,7 @@ export function initCommands_definitions() {
 				respond(`You cannot change into this pose as the rule '${ruleState.ruleDefinition.name}' forbids it.`);
 				return false;
 			}
-			CharacterSetActivePose(Player, pose);
+			PoseSetActive(Player, pose);
 			ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
 			if (!sender.isPlayer()) {
 				const text = legsTexts[argv[0].toLowerCase()];
@@ -293,7 +293,7 @@ export function initCommands_definitions() {
 				respond(`You cannot change into this pose as the rule '${ruleState.ruleDefinition.name}' forbids it.`);
 				return false;
 			}
-			CharacterSetActivePose(Player, pose);
+			PoseSetActive(Player, pose);
 			ServerSend("ChatRoomCharacterPoseUpdate", { Pose: Player.ActivePose });
 			if (!sender.isPlayer()) {
 				const text = "SENDER_NAME (SENDER_NUMBER) made you get on all fours";
@@ -618,7 +618,7 @@ export function initCommands_definitions() {
 				respond(`${Player.Name} must be able to walk and talk or the maids will not take her in for the job.`);
 				return false;
 			}
-			CharacterSetActivePose(Player, null);
+			PoseSetActive(Player, null);
 			const D = `(Two maids grab you and escort you to their quarters.  Another maid addresses you.)  ${sender.Name} sent you here to work.`;
 			ChatRoomActionMessage(`TargetCharacterName gets grabbed by two maids and escorted to the maid quarters to serve drinks, following SourceCharacter's (${sender.MemberNumber}) command.`, null, [
 				{ Tag: "TargetCharacterName", MemberNumber: Player.MemberNumber, Text: CharacterNickname(Player) },

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ export const FUNCTION_HASHES: Record<string, string[]> = {
 	BackgroundSelectionRun: ["F7AF6FF2"],
 	CharacterAppearanceGenderAllowed: ["8A2D647F"],
 	CharacterAppearanceLoadCharacter: ["EB80DBCE"],
-	CharacterCanChangeToPose: ["F55FE4B0"],
+	PoseCanChangeUnaided: ["F55FE4B0"],
 	CharacterCanKneel: ["A5A325E3"],
 	CharacterLoadCanvas: ["BA6AD4FF"],
 	CharacterLoadEffect: ["BD6B6B4D"],

--- a/src/rules/bc_blocks.ts
+++ b/src/rules/bc_blocks.ts
@@ -462,7 +462,7 @@ export function initRules_bc_blocks() {
 		},
 		load(state) {
 			let bypassPoseChange = false;
-			hookFunction("CharacterCanChangeToPose", 3, (args, next) => {
+			hookFunction("PoseCanChangeUnaided", 3, (args, next) => {
 				if (!bypassPoseChange && state.isEnforced && state.customData?.poseButtons.includes(args[1]))
 					return false;
 				return next(args);


### PR DESCRIPTION
This PR updates the names of two pose-related functions that were part of the R99 pose cleanup, them being moved to the new Pose.js namespace (xref [BondageProjects/Bondage-College#4606](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4606)):
* `CharacterSetActivePose` -> `PoseSetActive`
* `CharacterCanChangeToPose` -> `PoseCanChangeUnaided`