### PR TITLE
[REFACTOR] Use `PoseCanChangeUnaidedStatus()` as the sole hook target for the "Restrict allowed body poses" rule

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -348,7 +348,7 @@ type BCX_Rule =
 
 type RuleCustomData = {
 	block_restrict_allowed_poses: {
-		poseButtons: string[];
+		poseButtons: AssetPoseName[];
 	};
 	block_entering_rooms: {
 		roomList: string[];

--- a/src/rules/bc_blocks.ts
+++ b/src/rules/bc_blocks.ts
@@ -461,31 +461,13 @@ export function initRules_bc_blocks() {
 			},
 		},
 		load(state) {
-			let bypassPoseChange = false;
-			hookFunction("PoseCanChangeUnaided", 3, (args, next) => {
-				if (!bypassPoseChange && state.isEnforced && state.customData?.poseButtons.includes(args[1]))
-					return false;
-				return next(args);
-			}, ModuleCategory.Rules);
-			hookFunction("ChatRoomCanAttemptStand", 3, (args, next) => {
-				if (state.isEnforced && state.customData?.poseButtons.includes("BaseLower"))
-					return false;
-				return next(args);
-			}, ModuleCategory.Rules);
-			hookFunction("ChatRoomCanAttemptKneel", 3, (args, next) => {
-				if (state.isEnforced && state.customData?.poseButtons.includes("Kneel"))
-					return false;
-				return next(args);
-			}, ModuleCategory.Rules);
-			hookFunction("CharacterCanKneel", 3, (args, next) => {
-				if (state.isEnforced && state.customData?.poseButtons.includes("Kneel") && !Player.IsKneeling())
-					return false;
-				if (state.isEnforced && state.customData?.poseButtons.includes("BaseLower") && Player.IsKneeling())
-					return false;
-				bypassPoseChange = true;
-				const res = next(args);
-				bypassPoseChange = false;
-				return res;
+			hookFunction("PoseCanChangeUnaidedStatus", 0, ([C, poseName, ...args], next) => {
+				const status = next([C, poseName, ...args]);
+				if (C?.IsPlayer() && state.isEnforced && state.customData?.poseButtons.includes(poseName)) {
+					return Math.min(status, PoseChangeStatus.NEVER_WITHOUT_AID) as PoseChangeStatus;
+				} else {
+					return status;
+				}
 			}, ModuleCategory.Rules);
 		},
 	});


### PR DESCRIPTION
Use the new `PoseCanChangeUnaidedStatus()` function (xref [BondageProjects/Bondage-College#4960](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4960)) as hook target for the "Restrict allowed body poses" rule, replacing the previous four pose-related hooks with a single one. 

`PoseCanChangeUnaidedStatus()` is a new R104 function that consolidates the logic for all _conditional_ pose changes, returning a status code denoting whether or not a pose is allowed and, if so, under what conditions it is allowed (_e.g._ whether it requires external aid or usage of the standing/kneeling minigame).