### PR TITLE
[FIX] ChatRoomCreateElement hook breaking return values

### DIFF
--- a/src/modules/chatroom.ts
+++ b/src/modules/chatroom.ts
@@ -281,8 +281,9 @@ export class ModuleChatroom extends BaseModule {
 
 		if (!NMod) {
 			hookFunction("ChatRoomCreateElement", 0, (args, next) => {
-				next(args);
+				const res = next(args);
 				ChatroomSM.SetInputElement(document.getElementById("InputChat") as HTMLTextAreaElement);
+				return res;
 			});
 		}
 


### PR DESCRIPTION
This is breaking other addons hooking `ChatRoomCreateElement ` to have the expected args.