### PR TITLE
[CHORE] R111: Adapt the item search bar to the dialog `item` mode rework

### DIFF
--- a/src/modules/console.ts
+++ b/src/modules/console.ts
@@ -156,12 +156,14 @@ export class ModuleConsole extends BaseModule {
 	load() {
 		window.bcx = consoleInterface;
 
-		hookFunction("DialogDrawItemMenu", 0, (args, next) => {
-			if (developmentMode) {
-				DialogTextDefault = args[0].FocusGroup?.Description || "";
-			}
-			return next(args);
-		});
+		if (GameVersion === "R110") {
+			hookFunction("DialogDrawItemMenu", 0, (args, next) => {
+				if (developmentMode) {
+					DialogTextDefault = args[0].FocusGroup?.Description || "";
+				}
+				return next(args);
+			});
+		}
 
 		DialogSelfMenuOptions.forEach(opt => {
 			if (opt.Name === "Pose") {

--- a/src/rules/bc_blocks.ts
+++ b/src/rules/bc_blocks.ts
@@ -48,7 +48,8 @@ export function initRules_bc_blocks() {
 				return false;
 			});
 			hookFunction("DialogItemClick", 3, (args, next) => {
-				const C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+				// @ts-expect-error: `C` parameter added to `DialogItemClick` as of R111
+				const C = GameVersion !== "R110" ? args[1] : (Player.FocusGroup != null ? Player : CurrentCharacter);
 				if (C && C.ID === 0 && state.isEnforced && args[0].Asset.Name === "VibratorRemote") {
 					state.triggerAttempt();
 					return;
@@ -98,7 +99,8 @@ export function initRules_bc_blocks() {
 				return false;
 			});
 			hookFunction("DialogItemClick", 3, (args, next) => {
-				const C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+				// @ts-expect-error: `C` parameter added to `DialogItemClick` as of R111
+				const C = GameVersion !== "R110" ? args[1] : (Player.FocusGroup != null ? Player : CurrentCharacter);
 				if (C && C.ID !== 0 && state.isEnforced && args[0].Asset.Name === "VibratorRemote") {
 					state.triggerAttempt(C.MemberNumber);
 					return;
@@ -737,7 +739,8 @@ export function initRules_bc_blocks() {
 			hookFunction("DialogItemClick", 5, (args, next) => {
 				if (state.inEffect && state.customData) {
 					const toggleOn = state.customData.onlyMoreDominantsToggle;
-					const C = (Player.FocusGroup != null) ? Player : CurrentCharacter;
+					// @ts-expect-error: `C` parameter added to `DialogItemClick` as of R111
+					const C = GameVersion !== "R110" ? args[1] : (Player.FocusGroup != null ? Player : CurrentCharacter);
 					if (C && C.ID !== 0 && (toggleOn ? ReputationCharacterGet(Player, "Dominant") < ReputationCharacterGet(C, "Dominant") : true)) {
 						if (state.isEnforced) {
 							state.triggerAttempt(C.MemberNumber);
@@ -747,7 +750,7 @@ export function initRules_bc_blocks() {
 						}
 					}
 				}
-				next(args);
+				return next(args);
 			}, ModuleCategory.Rules);
 			hookFunction("AppearanceGetPreviewImageColor", 5, (args, next) => {
 				const toggleOn = state.customData?.onlyMoreDominantsToggle;


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5278](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5278)

Aforementioned PR overhauls, among others, the dialog `item` subscreen, converting it from a canvas- to DOM-based UI. The main compatibility change introduced herein concerns the search mode, which now, per the `data-unload` boolean attribute, simply hides the relevant button rather than regenerating the entire `DialogInventory` array.