### PR TITLE
[FIX] Adds compatibility for room whitelist changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bondage-club-extended",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"repository": "git@github.com:jomshir98/bondage-club-extended.git",
 	"author": "jomshir98 <jomshir98@protonmail.com>",
 	"license": "GPL-3.0",
@@ -28,7 +28,7 @@
 		"@types/jest": "^29.5.6",
 		"@typescript-eslint/eslint-plugin": "^6.9.0",
 		"@typescript-eslint/parser": "^6.9.0",
-		"bc-stubs": "github:bananarama92/BC-stubs#v107.0.0",
+		"bc-stubs": "github:bananarama92/BC-stubs#v111.0.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"copy-webpack-plugin": "^11.0.0",
 		"cross-env": "^7.0.3",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -749,6 +749,7 @@ interface RoomTemplate {
 	Language: ServerChatRoomLanguage;
 	Limit: string;
 	Admin: number[];
+	Whitelist: number[];
 	Game: ServerChatRoomGame;
 	Private: boolean;
 	Locked: boolean;

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -30,5 +30,9 @@ export function runMigration(originalVersion: BCXVersion, currentVersion: BCXVer
 		}
 	}
 
+	if (BCXVersionCompare(originalVersion, { major: 1, minor: 0, patch: 3 }) < 0) {
+		modStorage.roomTemplates?.filter(t => t && !t.Whitelist).forEach(t => t!.Whitelist = []);
+	}
+
 	return true;
 }

--- a/src/modules/chatroomAdmin.ts
+++ b/src/modules/chatroomAdmin.ts
@@ -462,8 +462,8 @@ function ChatSettingsExtraRun() {
 	if (onThemeRoomSubpage) {
 		return ChatSettingsThemeRoomRun();
 	}
-	DrawText("Back", 169, 110, "Black", "Gray");
-	DrawButton(124, 147, 90, 90, "", "White", "Icons/West.png");
+	DrawText("Back", 169, 95, "Black", "Gray");
+	DrawButton(124, 132, 90, 90, "", "White", "Icons/West.png");
 
 	DrawText("Standardize your room description so the room's purpose is clear and it can easily be filtered:", 1000, 300, "Black", "Gray");
 	DrawButton(800, 360, 380, 80, "Create a theme room", "white");
@@ -499,7 +499,7 @@ function ChatSettingsExtraClick(create: boolean, apply: (data: RoomTemplate) => 
 	if (onThemeRoomSubpage) {
 		return ChatSettingsThemeRoomClick();
 	}
-	if (MouseIn(124, 147, 90, 90)) {
+	if (MouseIn(124, 132, 90, 90)) {
 		overwriteMode = undefined;
 		onSecondPage = !onSecondPage;
 		ElementToggleGeneratedElements(CurrentScreen, true);
@@ -562,6 +562,7 @@ function ChatSettingsExtraClick(create: boolean, apply: (data: RoomTemplate) => 
 				Locked: create ? (ChatCreateLocked ? ChatCreateLocked : false) : ChatAdminLocked,
 				Game: create ? ChatCreateGame : ChatAdminGame,
 				Admin: ElementValue("InputAdminList") ? CommonConvertStringToArray(ElementValue("InputAdminList")!.trim()) : [],
+				Whitelist: ElementValue("InputWhitelist") ? CommonConvertStringToArray(ElementValue("InputWhitelist")!.trim()) : [],
 				Limit: ElementValue("InputSize") ? ElementValue("InputSize")!.trim() : "",
 				Language: create ? ChatCreateLanguage : ChatAdminLanguage,
 				BlockCategory: cloneDeep(create ? ChatBlockItemCategory : ChatAdminBlockCategory),
@@ -603,25 +604,25 @@ export class ModuleChatroomAdmin extends BaseModule {
 			ChatSettingsExtraExit();
 		});
 		patchFunction("ChatCreateRun", {
-			'DrawText(TextGet("RoomName"), 250, 120,': 'DrawText(TextGet("RoomName"), 370, 120,',
+			'DrawText(TextGet("RoomName"), 250, 105,': 'DrawText(TextGet("RoomName"), 370, 105,',
 		});
 		patchFunction("ChatCreateRun", {
-			'ElementPosition("InputName", 815, 115, 820);': 'ElementPosition("InputName", 865, 115, 720);',
+			'ElementPosition("InputName", 815, 100, 820);': 'ElementPosition("InputName", 865, 100, 720);',
 		});
 		patchFunction("ChatCreateRun", {
-			'DrawText(TextGet("RoomLanguage"), 250, 205,': 'DrawText(TextGet("RoomLanguage"), 390, 205,',
+			'DrawText(TextGet("RoomLanguage"), 250, 190,': 'DrawText(TextGet("RoomLanguage"), 390, 190,',
 		});
 		patchFunction("ChatCreateRun", {
-			"DrawButton(405, 172,": "DrawButton(505, 172,",
+			"DrawButton(405, 157,": "DrawButton(505, 157,",
 		});
 		patchFunction("ChatCreateRun", {
-			'DrawText(TextGet("RoomSize"), 850, 205,': 'DrawText(TextGet("RoomSize"), 950, 205,',
+			'DrawText(TextGet("RoomSize"), 850, 190,': 'DrawText(TextGet("RoomSize"), 950, 190,',
 		});
 		patchFunction("ChatCreateRun", {
-			'ElementPosition("InputSize", 1099, 200, 250);': 'ElementPosition("InputSize", 1149, 200, 150);',
+			'ElementPosition("InputSize", 1099, 185, 250);': 'ElementPosition("InputSize", 1149, 185, 150);',
 		});
 		patchFunction("ChatCreateClick", {
-			"if (MouseIn(405, 172,": "if (MouseIn(505, 172,",
+			"if (MouseIn(405, 157,": "if (MouseIn(505, 157,",
 		});
 		hookFunction("ChatCreateRun", 0, (args, next) => {
 			onRoomCreateScreen = true;
@@ -630,9 +631,9 @@ export class ModuleChatroomAdmin extends BaseModule {
 			}
 			next(args);
 			if (!ChatCreateShowBackgroundMode) {
-				DrawText("More", 169, 110, "Black", "Gray");
-				DrawButton(124, 147, 90, 90, "", "White", icon_BCX);
-				if (MouseIn(124, 147, 90, 90)) DrawButtonHover(-36, 70, 64, 64, `More options [BCX]`);
+				DrawText("More", 169, 95, "Black", "Gray");
+				DrawButton(124, 132, 90, 90, "", "White", icon_BCX);
+				if (MouseIn(124, 132, 90, 90)) DrawButtonHover(-36, 55, 64, 64, `More options [BCX]`);
 			}
 		});
 		hookFunction("ChatAdminExit", 0, (args, next) => {
@@ -651,6 +652,7 @@ export class ModuleChatroomAdmin extends BaseModule {
 				const inputName = document.getElementById("InputName") as HTMLInputElement | undefined;
 				const inputDescription = document.getElementById("InputDescription") as HTMLInputElement | undefined;
 				const inputAdminList = document.getElementById("InputAdminList") as HTMLTextAreaElement | undefined;
+				const inputWhitelist = document.getElementById("InputWhitelist") as HTMLTextAreaElement | undefined;
 				const inputSize = document.getElementById("InputSize") as HTMLInputElement | undefined;
 
 				if (inputName) inputName.value = template.Name;
@@ -660,6 +662,7 @@ export class ModuleChatroomAdmin extends BaseModule {
 				ChatCreateLocked = template.Locked;
 				ChatCreateGame = template.Game;
 				if (inputAdminList) inputAdminList.value = template.Admin.toString();
+				if (inputWhitelist) inputWhitelist.value = template.Whitelist.toString();
 				if (inputSize) inputSize.value = template.Limit;
 				if (template.Language) ChatCreateLanguage = template.Language;
 				ChatBlockItemCategory = template.BlockCategory;
@@ -675,6 +678,7 @@ export class ModuleChatroomAdmin extends BaseModule {
 					const inputName = document.getElementById("InputName") as HTMLInputElement | undefined;
 					const inputDescription = document.getElementById("InputDescription") as HTMLInputElement | undefined;
 					const inputAdminList = document.getElementById("InputAdminList") as HTMLTextAreaElement | undefined;
+					const inputWhitelist = document.getElementById("InputWhitelist") as HTMLTextAreaElement | undefined;
 					const inputSize = document.getElementById("InputSize") as HTMLInputElement | undefined;
 
 					if (inputName) inputName.value = data.Name;
@@ -684,13 +688,14 @@ export class ModuleChatroomAdmin extends BaseModule {
 					ChatCreateLocked = data.Locked;
 					ChatCreateGame = data.Game;
 					if (inputAdminList) inputAdminList.value = data.Admin.toString();
+					if (inputWhitelist) inputWhitelist.value = data.Whitelist.toString();
 					if (inputSize) inputSize.value = data.Limit;
 					if (data.Language) ChatCreateLanguage = data.Language;
 					ChatBlockItemCategory = data.BlockCategory;
 				});
 			}
 			// click event for second page button
-			if (MouseIn(124, 147, 90, 90)) {
+			if (MouseIn(124, 132, 90, 90)) {
 				onSecondPage = !onSecondPage;
 				ElementToggleGeneratedElements("ChatCreate", false);
 				return;
@@ -699,25 +704,25 @@ export class ModuleChatroomAdmin extends BaseModule {
 		});
 		//#region Second page button (on room admin screen)
 		patchFunction("ChatAdminRun", {
-			'DrawText(TextGet("RoomName"), 250, 120,': 'DrawText(TextGet("RoomName"), 370, 120,',
+			'DrawText(TextGet("RoomName"), 250, 105,': 'DrawText(TextGet("RoomName"), 370, 105,',
 		});
 		patchFunction("ChatAdminRun", {
-			'ElementPosition("InputName", 815, 115, 820);': 'ElementPosition("InputName", 865, 115, 720);',
+			'ElementPosition("InputName", 815, 100, 820);': 'ElementPosition("InputName", 865, 100, 720);',
 		});
 		patchFunction("ChatAdminRun", {
-			'DrawText(TextGet("RoomLanguage"), 250, 205,': 'DrawText(TextGet("RoomLanguage"), 390, 205,',
+			'DrawText(TextGet("RoomLanguage"), 250, 190,': 'DrawText(TextGet("RoomLanguage"), 390, 190,',
 		});
 		patchFunction("ChatAdminRun", {
-			"DrawButton(405, 172,": "DrawButton(505, 172,",
+			"DrawButton(405, 157,": "DrawButton(505, 157,",
 		});
 		patchFunction("ChatAdminRun", {
-			'DrawText(TextGet("RoomSize"), 850, 205,': 'DrawText(TextGet("RoomSize"), 950, 205,',
+			'DrawText(TextGet("RoomSize"), 850, 190,': 'DrawText(TextGet("RoomSize"), 950, 190,',
 		});
 		patchFunction("ChatAdminRun", {
-			'ElementPosition("InputSize", 1099, 200, 250);': 'ElementPosition("InputSize", 1149, 200, 150);',
+			'ElementPosition("InputSize", 1099, 185, 250);': 'ElementPosition("InputSize", 1149, 185, 150);',
 		});
 		patchFunction("ChatAdminClick", {
-			"if (MouseIn(405, 172,": "if (MouseIn(505, 172,",
+			"if (MouseIn(405, 157,": "if (MouseIn(505, 157,",
 		});
 		hookFunction("ChatAdminRun", 0, (args, next) => {
 			onRoomCreateScreen = false;
@@ -725,9 +730,9 @@ export class ModuleChatroomAdmin extends BaseModule {
 				return ChatSettingsExtraRun();
 			}
 			next(args);
-			DrawText("More", 169, 110, "Black", "Gray");
-			DrawButton(124, 147, 90, 90, "", "White", icon_BCX);
-			if (MouseIn(124, 147, 90, 90)) DrawButtonHover(-36, 70, 64, 64, `More options [BCX]`);
+			DrawText("More", 169, 95, "Black", "Gray");
+			DrawButton(124, 132, 90, 90, "", "White", icon_BCX);
+			if (MouseIn(124, 132, 90, 90)) DrawButtonHover(-36, 55, 64, 64, `More options [BCX]`);
 		});
 		//#endregion
 		hookFunction("ChatAdminClick", 0, (args, next) => {
@@ -736,6 +741,7 @@ export class ModuleChatroomAdmin extends BaseModule {
 					const inputName = document.getElementById("InputName") as HTMLInputElement | undefined;
 					const inputDescription = document.getElementById("InputDescription") as HTMLInputElement | undefined;
 					const inputAdminList = document.getElementById("InputAdminList") as HTMLTextAreaElement | undefined;
+					const inputWhitelist = document.getElementById("InputWhitelist") as HTMLTextAreaElement | undefined;
 					const inputSize = document.getElementById("InputSize") as HTMLInputElement | undefined;
 
 					if (inputName) inputName.value = data.Name;
@@ -745,13 +751,14 @@ export class ModuleChatroomAdmin extends BaseModule {
 					ChatAdminLocked = data.Locked;
 					ChatAdminGame = data.Game;
 					if (inputAdminList) inputAdminList.value = data.Admin.toString();
+					if (inputWhitelist) inputWhitelist.value = data.Whitelist.toString();
 					if (inputSize) inputSize.value = data.Limit;
 					if (data.Language) ChatAdminLanguage = data.Language;
 					ChatAdminBlockCategory = data.BlockCategory;
 				});
 			}
 			// click event for second page button
-			if (MouseIn(124, 147, 90, 90)) {
+			if (MouseIn(124, 132, 90, 90)) {
 				onSecondPage = !onSecondPage;
 				ElementToggleGeneratedElements("ChatAdmin", false);
 				return;

--- a/src/modules/clubUtils.ts
+++ b/src/modules/clubUtils.ts
@@ -323,7 +323,7 @@ export class ModuleClubUtils extends BaseModule {
 							ServerSend("ChatRoomAdmin", { MemberNumber: character.MemberNumber, Action: "Promote" });
 						}
 					}
-				} else if (subcommand === "promote" || subcommand === "demote" || subcommand === "kick" || subcommand === "ban" || subcommand === "permaban") {
+				} else if (subcommand === "promote" || subcommand === "demote" || subcommand === "whitelist" || subcommand === "unwhitelist" || subcommand === "kick" || subcommand === "ban" || subcommand === "permaban") {
 					if (args.length === 1) {
 						ChatRoomSendLocal(`Needs at least one character name oder member number as <target> in '.room ${subcommand} <target1> <target2> <targetN>'`);
 						return false;
@@ -347,6 +347,15 @@ export class ModuleClubUtils extends BaseModule {
 							return !targetsToDemote.has(target);
 						});
 						updateChatroom({ Admin });
+					} else if (subcommand === "whitelist") {
+						const Whitelist = arrayUnique(ChatRoomData.Whitelist.concat(targets));
+						updateChatroom({ Whitelist });
+					} else if (subcommand === "unwhitelist") {
+						const targetsToUnwhitelist = new Set(targets);
+						const Whitelist = ChatRoomData.Whitelist.filter((target) => {
+							return !targetsToUnwhitelist.has(target);
+						});
+						updateChatroom({ Whitelist });
 					} else if (subcommand === "kick") {
 						for (const target of targets) {
 							ServerSend("ChatRoomAdmin", { MemberNumber: target, Action: "Kick", Publish: false });
@@ -381,6 +390,7 @@ export class ModuleClubUtils extends BaseModule {
 						Locked: template.Locked,
 						Game: template.Game,
 						Admin: template.Admin,
+						Whitelist: template.Whitelist,
 						Limit: size,
 						BlockCategory: template.BlockCategory,
 					});
@@ -396,6 +406,7 @@ export class ModuleClubUtils extends BaseModule {
 						`.room permaban <...targets> - Bans and blacklists all specified player names or numbers\n` +
 						`.room <promote/demote> <...targets> - Adds or removes admin on all specified player names or numbers\n` +
 						`.room promoteall - Gives admin to all non-admin players in the room\n` +
+						`.room <whitelist/unwhitelist> <...targets> - Whitelists or unwhitelists all specified player names or numbers in the room\n` +
 						`.room template <1/2/3/4> - Changes the room according to the given BCX room template slot`
 					);
 				}


### PR DESCRIPTION
This PR pre-emptively adds compatibility with the upcoming R111 room whitelist change ([client!5281](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5281)), including support for room whitelists in room templates, the `.room` command, and updates to the UI patches to ensure the BCX "more options" menu is placed properly.

As this is a pre-emptive PR and R111 is not yet released, this PR is being marked as a draft (however, at the time of writing: is tested and functional). Upon the public release of R111, it's recommended to quickly re-test this PR in case of any additional changes that were implemented since its creation.

### Notes
- As this is pre-emptive and `bc-stubs` has not yet been updated for R111, the CI check will likely fail
- As a migration was added in this PR, the version number was correspondingly bumped to ensure it takes place (`1.0.2` -> `1.0.3`)
- Backwards compatibility from R110 → R111 is:
	- Ensured for the room templates
		- R110 will simply not set the whitelist property on load, and save an empty whitelist to the template on save
	- Not ensured for the `.room` command
		- attempts to run the `.room whitelist/unwhitelist` commands on previous versions will lead to an error
		- it was decided *not* to add compatibility as most users will be on the latest version, and there is no impact to any that aren't so long as they don't use the command
	- Not ensured for the "More Options" UI placement
		- "More Options" button will appear on top of the "Room Name" and "Language" labels
		- purely visual, the UI will remain functional
		- the only solution for this would be to leave patches in for the coordinates for both R111 and previous UIs, which is overall a poor idea
- During the R111 beta period, for users on the Beta R111 client (as this PR will not have been merged yet):
	- The "More Options" button in the UI will appear on top of the "Room Name" and "Language" labels, as the patch fails -- this is purely cosmetic
	- Templates will not properly save or populate the Whitelist field -- it'll simply be left alone
- Overall, it is recommended to merge these changes following the *public* release of R111, rather than the *beta* release to minimize the overall impact (users on beta will only experience a feature not working as intended, and a minor cosmetic issue).
- A subsequent fix will likely be required with the breaking changes made by the ChatCreate & ChatAdmin merge upcoming in R112 ([client!5282](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5282))