### PR TITLE
[CHORE] Ensure that a character is passed along `DialogIntro()` in R113

### DIFF
--- a/src/modules/dialog.ts
+++ b/src/modules/dialog.ts
@@ -17,7 +17,8 @@ function allowSearchMode(): boolean {
 				CurrentCharacter.AllowItem
 			)
 		) &&
-		DialogIntro() !== "" &&
+		// @ts-expect-error: new parameter added in R113; still inert as of R112
+		DialogIntro(CurrentCharacter) !== "" &&
 		(DialogMenuMode === "items" || DialogMenuMode === "permissions");
 }
 


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5358](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5358)

Ensure that the character is now explicitly passed along to the `DialogIntro()` call.