### PR TITLE
[CHORE] Adapt "Fully blind when eyes are closed" rule to R115 changes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,9 @@ function replaceReferencedFunctions() {
 	// Run patching replacer on objects that hold references to patched functions
 	replacePatchedMethodsDeep("ChatRoomViews", ChatRoomViews);
 	replacePatchedMethodsDeep("CurrentScreenFunctions", CurrentScreenFunctions);
-	replacePatchedMethodsDeep("DialogSelfMenuOptions", DialogSelfMenuOptions);
+	if (GameVersion === "R114") {
+		replacePatchedMethodsDeep("DialogSelfMenuOptions", DialogSelfMenuOptions);
+	}
 }
 
 export function init() {

--- a/src/modules/console.ts
+++ b/src/modules/console.ts
@@ -155,11 +155,13 @@ export class ModuleConsole extends BaseModule {
 	load() {
 		window.bcx = consoleInterface;
 
-		DialogSelfMenuOptions.forEach(opt => {
-			if (opt.Name === "Pose") {
-				opt.IsAvailable = () => true;
-			}
-		});
+		if (GameVersion === "R114") {
+			DialogSelfMenuOptions.forEach(opt => {
+				if (opt.Name === "Pose") {
+					opt.IsAvailable = () => true;
+				}
+			});
+		}
 	}
 
 	run() {

--- a/src/rules/bc_alter.ts
+++ b/src/rules/bc_alter.ts
@@ -10,6 +10,28 @@ import { BCX_setTimeout } from "../BCXContext";
 import { queryHandlers, sendQuery } from "../modules/messaging";
 import { isValidNickname } from "../modules/relationships";
 
+// >= R115 stuff
+
+interface MenuButtonValidateData {
+	state: null | "hidden" | "disabled";
+	status?: null | string;
+}
+
+type MenuButtonValidator = (
+	button: HTMLButtonElement,
+	properties: { C: PlayerCharacter; },
+	equippedItem?: Item | null
+) => MenuButtonValidateData | null;
+
+declare const DialogSelfMenuMapping: {
+	Expression: DialogMenu & {
+		menubarEventListeners: Record<string, {
+			click(button: HTMLButtonElement, ev: MouseEvent, properties: { C: PlayerCharacter; }, equippedItem?: null | Item): any;
+			validate?: Record<string, MenuButtonValidator>;
+		}>;
+	};
+};
+
 export function initRules_bc_alter() {
 	registerRule("alt_restrict_hearing", {
 		name: "Sensory deprivation: Sound",
@@ -174,11 +196,18 @@ export function initRules_bc_alter() {
 			return false;
 		},
 		load(state) {
-			hookFunction("DialogClickExpressionMenu", 5, (args, next) => {
-				if (state.isEnforced && MouseIn(220, 50, 90, 90))
-					return;
-				return next(args);
-			});
+			if (GameVersion === "R114") {
+				hookFunction("DialogClickExpressionMenu", 5, (args, next) => {
+					if (state.isEnforced && MouseIn(220, 50, 90, 90))
+						return;
+					return next(args);
+				});
+			} else {
+				(DialogSelfMenuMapping.Expression.menubarEventListeners.blindness.validate ??= {}).bcx = () => {
+					return state.isEnforced ? { state: "disabled", status: 'Restricted by BCX rule: "Fully blind when eyes are closed"' } : null;
+				};
+			}
+
 			hookFunction("ChatRoomCharacterViewDraw", 1, (args, next) => {
 				const ChatRoomHideIconStateBackup = ChatRoomHideIconState;
 				const eyes1 = InventoryGet(Player, "Eyes");
@@ -212,6 +241,17 @@ export function initRules_bc_alter() {
 					return;
 				return next(args);
 			});
+		},
+		stateChange(state, newState) {
+			if (
+				newState
+				&& GameVersion !== "R114"
+				&& (DialogSelfMenuSelected as unknown) === "Expression" // Remove `unknown` cast once R115 stubs are available
+				&& DialogSelfMenuMapping.Expression.C === Player
+			) {
+				// If the expression menu is open, reload it in order to re-evaluate the disabled state of the `blindness` menu button
+				DialogSelfMenuMapping.Expression.Reload();
+			}
 		},
 	});
 


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5516](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5516)

Adapts BCX to the R115 changes for the left-most dialog side panels, converting them from canvas to DOM. Among others this includes the facial expression panel, which is relevant here for BCX due to the `Fully blind when eyes are closed` rule, which hooks into it in order to disable the blindness-level button.

Marking as draft until the upstream PR has been merged.