### PR TITLE
[FEATURE] Improve greet_new_guests rule

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -477,6 +477,7 @@ type RuleCustomData = {
 	};
 	greet_new_guests: {
 		greetingSentence: string;
+		minimumRole: Exclude<import("./modules/authority").AccessLevel, 0>;
 	};
 	// speech_restrained_speech: {
 	// 	listOfAllowedSentences: string[];

--- a/src/rules/speech_control.ts
+++ b/src/rules/speech_control.ts
@@ -5,8 +5,10 @@ import { registerSpeechHook, SpeechMessageInfo, falteringSpeech, SpeechHookAllow
 import { callOriginal, hookFunction } from "../patching";
 import { getChatroomCharacter } from "../characters";
 import { dictionaryProcess, escapeRegExp, isObject } from "../utils";
-import { ChatRoomSendLocal } from "../utilsClub";
+import { ChatRoomSendLocal, getCharacterName } from "../utilsClub";
 import { BCX_setTimeout } from "../BCXContext";
+import { modStorage } from "../modules/storage";
+import { moduleIsEnabled } from "../modules/presets";
 
 function checkMessageForSounds(sounds: string[], message: string, allowPartialMatch: boolean = true): boolean {
 	for (let sound of sounds) {
@@ -890,15 +892,21 @@ export function initRules_bc_speech_control() {
 		type: RuleType.Speech,
 		loggable: false,
 		shortDescription: "when they join the current room",
-		longDescription: "Forces PLAYER_NAME to greet people newly entering the current chat room with the set sentence. NOTE: Only PLAYER_NAME and the new guest can see the message not to make it spammy. After a new person has been greeted, she will not be greeted for 10 minutes after she left (including disconnect) the room PLAYER_NAME is in. Setting an emote as a greeting is also supported by starting the set message with one or two '*' characters.",
+		longDescription: "Forces PLAYER_NAME to greet people newly entering the current chat room with the set sentence. NOTE: Only PLAYER_NAME and the new guest can see the message not to make it spammy. After a new person has been greeted, she will not be greeted for 10 minutes after she left (including disconnect) the room PLAYER_NAME is in. Setting an emote as a greeting is also supported by starting the set message with one or two '*' characters. %name% is replaced by the name from the relationships module or their normal name. The %titled_name% prepends Master/Mistress/Owner.",
 		keywords: ["say", "present", "introduce"],
 		defaultLimit: ConditionsLimit.limited,
 		dataDefinition: {
 			greetingSentence: {
 				type: "string",
 				default: "",
-				description: "The sentence that will be used to greet new guests:",
+				description: `The sentence that will be used to greet new guests:`,
 				options: /^([^/.].*)?$/,
+			},
+			minimumRole: {
+				type: "roleSelector",
+				default: AccessLevel.public,
+				description: "Minimum role that will be greeted",
+				Y: 450,
 			},
 		},
 		load(state) {
@@ -932,21 +940,46 @@ export function initRules_bc_speech_control() {
 								nextGreet.get(C.MemberNumber)! >= Date.now()
 							)
 						) return;
+
 						nextGreet.set(C.MemberNumber, 0);
-						if (state.customData.greetingSentence.startsWith("*")) {
-							const message = state.customData.greetingSentence.slice(1);
+
+						if (state.customData.minimumRole && getCharacterAccessLevel(C.MemberNumber) > state.customData.minimumRole) {
+							return;
+						}
+
+						const characterAccessLevel = getCharacterAccessLevel(C.MemberNumber);
+						const isOwner = characterAccessLevel === AccessLevel.owner || characterAccessLevel === AccessLevel.clubowner;
+						let title = isOwner ? 'Owner' : (C.GetGenders().includes("M") ? "Master" : "Mistress");
+						let name = getCharacterName(C.MemberNumber, "[unknown]");
+
+						if (moduleIsEnabled(ModuleCategory.Relationships) && modStorage.relationships)
+						{
+							const nickName = modStorage.relationships?.find(r => r.memberNumber === C.MemberNumber)?.nickname;
+
+							if (nickName) {
+								name = nickName;
+								title = '';
+							}
+						}
+
+						let sentence = state.customData.greetingSentence;
+						sentence = sentence.replace(/%titled_name%/g, title ? `${title} ${name}` : name);
+						sentence = sentence.replace(/%name%/g, name);
+
+						if (sentence.startsWith("*")) {
+							const message = sentence.slice(1);
 							ServerSend("ChatRoomChat", { Content: message, Type: "Emote", Target: C.MemberNumber });
 							ServerSend("ChatRoomChat", { Content: message, Type: "Emote", Target: Player.MemberNumber });
 						} else {
-							ServerSend("ChatRoomChat", { Content: state.customData.greetingSentence, Type: "Chat", Target: C.MemberNumber });
-							ServerSend("ChatRoomChat", { Content: state.customData.greetingSentence, Type: "Chat", Target: Player.MemberNumber });
+							ServerSend("ChatRoomChat", { Content: sentence, Type: "Chat", Target: C.MemberNumber });
+							ServerSend("ChatRoomChat", { Content: sentence, Type: "Chat", Target: Player.MemberNumber });
 						}
 					}, 5_000);
 				}
 			}, ModuleCategory.Rules);
 		},
 	});
-
+	
 	// Restrained speech:
 	// the wearer is unable to speak freely, she is given a set of sentences/targets allowed and can only use those with the #name talk command.
 	// The given sentences can contain the %target% placeholder to have the target inserted into the sentence. The given sentences can contain

--- a/src/rules/speech_control.ts
+++ b/src/rules/speech_control.ts
@@ -949,16 +949,15 @@ export function initRules_bc_speech_control() {
 
 						const characterAccessLevel = getCharacterAccessLevel(C.MemberNumber);
 						const isOwner = characterAccessLevel === AccessLevel.owner || characterAccessLevel === AccessLevel.clubowner;
-						let title = isOwner ? 'Owner' : (C.GetGenders().includes("M") ? "Master" : "Mistress");
+						let title = isOwner ? "Owner" : (C.GetGenders().includes("M") ? "Master" : "Mistress");
 						let name = getCharacterName(C.MemberNumber, "[unknown]");
 
-						if (moduleIsEnabled(ModuleCategory.Relationships) && modStorage.relationships)
-						{
+						if (moduleIsEnabled(ModuleCategory.Relationships) && modStorage.relationships) {
 							const nickName = modStorage.relationships?.find(r => r.memberNumber === C.MemberNumber)?.nickname;
 
 							if (nickName) {
 								name = nickName;
-								title = '';
+								title = "";
 							}
 						}
 
@@ -979,7 +978,7 @@ export function initRules_bc_speech_control() {
 			}, ModuleCategory.Rules);
 		},
 	});
-	
+
 	// Restrained speech:
 	// the wearer is unable to speak freely, she is given a set of sentences/targets allowed and can only use those with the #name talk command.
 	// The given sentences can contain the %target% placeholder to have the target inserted into the sentence. The given sentences can contain


### PR DESCRIPTION
Allows to configure the lowest role that one should greet.

For example only greet Mistresses, and not lower.

Also adds %name% and %titled_name% replacements.

%name% get the name from the relationship module, if it is enabled and have a name for the user. Else it uses the normal user name.
If it can get name from relationship module, then %titled_name% will use that name, making the result the same as %name%.
If there is no name in the relationship module, it will prepend Owner/Master/Mistress to the normal user name.

if BCX owner or clubowner, %titled_name% becomes "Owner <name>"
else if C.GetGenders().includes("M") gives true, it becomes "Master <name>"
else "Mistress <name>"

Examples:

"I am ready to serve you, %titled_name%!"

| Name      | Gender      | BCX role   |Relationship name |Result                                                        |
| ---------- | ----------- |------------ |-------------------- |--------------------------------------------- |
| Jane        | Female      | Owner      | <none>                |I am ready to serve you, Owner Jane!        |
| Jane        | Female      | Mistress    | <none>                |I am ready to serve you, Mistress Jane!     |
| Jane        | Female      | Public        | <none>                |I am ready to serve you, Mistress Jane!    |
| John        | Male         | Public        | <none>                |I am ready to serve you, Master John!      |
| Jane        | Female      | Public        | Goddess               |I am ready to serve you, Goddess!            |

"I am ready to serve you, %name%!"

| Name      | Gender      | BCX role   |Relationship name |Result                                                        |
| ---------- | ----------- |------------ |-------------------- |--------------------------------------------- |
| Jane        | Female      | Owner      | <none>                |I am ready to serve you, Jane!                   |
| Jane        | Female      | Public        | <none>                |I am ready to serve you, Jane!                   |
| John        | Male         | Public        | <none>                |I am ready to serve you, John!                  |
| Jane        | Female      | Public        | Goddess               |I am ready to serve you, Goddess!            |

Image of the new setting:

![image](https://github.com/user-attachments/assets/55be9b37-170f-4450-98c2-96712507b7e0)

Image of the new description:

![image](https://github.com/user-attachments/assets/dab2ae1b-cbd3-42a8-8196-1d9152407bb4)

The description is a bit messy (and had to remove info to make it fit), is there any good way to put the info about %name% and %titled_name% on the config page instead?
The description for greetingSentence did not like it when i put my long description there, as it seems to only support one line.
Can one add dummy dataDefinition that are only to have some instructive text?
Or is there a better way?