### PR TITLE
[FEATURE]  Add rule greet_on_slow_leave

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -313,6 +313,7 @@ type BCX_Rule =
 	| "speech_force_retype"
 	| "greet_room_order"
 	| "greet_new_guests"
+	| "greet_on_slow_leave"
 	// | "speech_restrained_speech"
 	| "speech_alter_faltering"
 	| "speech_mandatory_words"
@@ -476,6 +477,9 @@ type RuleCustomData = {
 		affectEmotes: boolean;
 	};
 	greet_new_guests: {
+		greetingSentence: string;
+	};
+	greet_on_slow_leave: {
 		greetingSentence: string;
 	};
 	// speech_restrained_speech: {


### PR DESCRIPTION
Adds a new rule "Greet on leave"

It will make the user say a certain text if they are leaving slowly.

It will not say it in the same room if it have said it in the past 10 minutes.

So if you start to leave, it says the text.
If you then stop the leave, and then start leave again, it will not say it, unless you wait 10 min before starting to leave again.
Same if you successfully leave the room, enter it again and start to leave. It will only say it again if it is 10 min since last time it said it in the room.
Refreshing the page resets the time, as the time track is in memory.

![image](https://github.com/user-attachments/assets/9883adc8-f9e1-4ab1-8905-b172f2cd5039)

![image](https://github.com/user-attachments/assets/f32152e4-6684-446e-b9cf-61f1d2471c85)

![image](https://github.com/user-attachments/assets/34b8901b-4f38-4328-98aa-b02aeb0f2303)
