### PR TITLE
[CHORE] Use `ChatRoomAppendChat()` for appending BCX messages to the chat log

### DIFF
--- a/src/utilsClub.ts
+++ b/src/utilsClub.ts
@@ -154,16 +154,8 @@ export function ChatRoomSendLocal(msg: string | Node, timeout?: number, sender?:
 	if (timeout) BCX_setTimeout(() => div.remove(), timeout);
 
 	// Returns the focus on the chat box
-	const Refocus = document.activeElement?.id === "InputChat";
-	const ShouldScrollDown = ElementIsScrolledToEnd("TextAreaChatLog");
-	const ChatLog = document.getElementById("TextAreaChatLog");
-	if (ChatLog != null) {
-		ChatLog.appendChild(div);
-		if (ShouldScrollDown) ElementScrollToEnd("TextAreaChatLog");
-		if (Refocus) ElementFocus("InputChat");
-		return div;
-	}
-	return null;
+	ChatRoomAppendChat(div);
+	return document.getElementById("TextAreaChatLog") ? div : null;
 }
 
 export function isNModClient(): boolean {


### PR DESCRIPTION
Use the more standard `ChatRoomAppendChat()` function for appending messages to the chat log.

This is particularly important in light of [BondageProjects/Bondage-College#5559](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5559) for R116, as aforementioned function is now used for setting the message's metadata-esque element with the time and sender number (previously a pseudo element; now a proper element).