### PR TITLE
[CHORE] Adapt to the R117 `[data-unload]` -> `[hidden]` attribute changes

### DIFF
--- a/src/modules/dialog.ts
+++ b/src/modules/dialog.ts
@@ -41,7 +41,7 @@ function enterSearchMode(C: Character, input?: string) {
 						const name = button.getAttribute("name")?.toLocaleLowerCase() ?? "";
 						const description = button.querySelector(".button-label")?.textContent?.toLocaleLowerCase() ?? "";
 						const queryMatch = query.some(i => name.includes(i) || description.includes(i));
-						button.toggleAttribute("data-unload", !queryMatch);
+						button.toggleAttribute("hidden", !queryMatch);
 					});
 				}
 			}
@@ -65,7 +65,7 @@ function exitSearchMode(C: Character) {
 		// @ts-expect-error: >= R111
 		const gridID: undefined | string = DialogMenuMapping[DialogMenuMode]?.ids.grid;
 		if (gridID) {
-			document.querySelectorAll(`#${gridID} > .dialog-grid-button`).forEach(button => button.toggleAttribute("data-unload", false));
+			document.querySelectorAll(`#${gridID} > .dialog-grid-button`).forEach(button => button.toggleAttribute("hidden", false));
 		}
 
 	}


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5589](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5589)

Fixes the search filtering being broken by switching to the more standard `[hidden]` attribute for hiding to-be ignored entries.