### PR TITLE
[FIX] Fix two `CommonSetScreen` hooks failing to return a return value

### DIFF
--- a/src/modules/chatroom.ts
+++ b/src/modules/chatroom.ts
@@ -383,8 +383,9 @@ export class ModuleChatroom extends BaseModule {
 
 		// Screen indicator
 		hookFunction("CommonSetScreen", 0, (args, next) => {
-			next(args);
+			const ret = next(args);
 			ChatroomSM.UpdateStatus();
+			return ret;
 		});
 		hookFunction("ItemColorStateBuild", 0, (args, next) => {
 			next(args);

--- a/src/rules/bc_blocks.ts
+++ b/src/rules/bc_blocks.ts
@@ -523,7 +523,7 @@ export function initRules_bc_blocks() {
 						state.trigger();
 					}
 				}
-				next(args);
+				return next(args);
 			}, ModuleCategory.Rules);
 		},
 	});


### PR DESCRIPTION
`CommonSetScreen()` has had its return type changed from `void` to `Promise<void>`; ensure that this value is actually passed along by the hooks.