### PR TITLE
[CHORE] Adapt to the R122 color picker changes

### DIFF
--- a/src/modules/curses.ts
+++ b/src/modules/curses.ts
@@ -42,11 +42,29 @@ const CURSE_INACTIVE_SCREENS: (() => boolean)[] = [
 	() => CurrentScreen === "ChatSelect",
 	() => CurrentScreen === "ChatSearch",
 	() => CurrentScreen === "ChatAdmin" && ChatAdminMode === "create",
+	() => GameVersion !== "R121" && ItemColorCurrentMode === ItemColorMode.COLOR_PICKER,
 ];
 
 // Pause curses on certain screens and when talking with NPC altogether
 function isCursePaused() {
 	return CURSE_INACTIVE_SCREENS.some(v => v()) || CurrentCharacter?.IsNpc();
+}
+
+// R122 type backport
+interface ColorPickerInitOptions {
+	/** A callback to-be executed upon closing the color picker. */
+	onExit?: (colorState: {
+		colors: string[];
+		opacity: number[];
+		initialColors: string[];
+		initialOpacity: number[];
+		defaultColors: string[];
+		defaultOpacity: number[];
+	}, save: boolean, root: null | HTMLElement) => void;
+	/** Whether the color picker should be disabled or not */
+	disabled?: boolean;
+	/** A custom heading to-be assigned to the color picker's `<h1>` element */
+	heading?: string | Element | readonly (string | Element)[];
 }
 
 export function curseMakeSavedProperty(properties: ItemProperties | undefined): ItemProperties {
@@ -930,37 +948,88 @@ export class ModuleCurses extends BaseModule {
 			return result;
 		}, ModuleCategory.Curses);
 
-		hookFunction("ColorPickerDraw", 0, (args, next) => {
-			const Callback = args[5] as (Color: string) => void;
-			if (Callback === ItemColorOnPickerChange) {
-				args[5] = (color: any) => {
-					if (ItemColorCharacter === Player && ItemColorItem) {
-						// Original code
-						const newColors = ItemColorState.colors.slice();
-						ItemColorPickerIndices.forEach(i => newColors[i] = color);
-						ItemColorItem.Color = newColors;
-						CharacterLoadCanvas(ItemColorCharacter);
-						// Curse color change code
-						const condition = ConditionsGetCondition("curses", ItemColorItem.Asset.Group.Name);
-						const curse = condition?.data;
-						if (curse &&
-							!itemColorsEquals(curse.Color, ItemColorItem.Color) &&
-							checkPermissionAccess("curses_color", getPlayerCharacter())
-						) {
-							if (ItemColorItem.Color) {
-								curse.Color = cloneDeep(ItemColorItem.Color);
-							} else {
-								delete curse.Color;
+		if (GameVersion === "R121") {
+			hookFunction("ColorPickerDraw", 0, (args, next) => {
+				const Callback = args[5] as (Color: string) => void;
+				if (Callback === ItemColorOnPickerChange) {
+					args[5] = (color: any) => {
+						if (ItemColorCharacter === Player && ItemColorItem) {
+							// Original code
+							const newColors = ItemColorState.colors.slice();
+							ItemColorPickerIndices.forEach(i => newColors[i] = color);
+							ItemColorItem.Color = newColors;
+							CharacterLoadCanvas(ItemColorCharacter);
+							// Curse color change code
+							const condition = ConditionsGetCondition("curses", ItemColorItem.Asset.Group.Name);
+							const curse = condition?.data;
+							if (curse &&
+								!itemColorsEquals(curse.Color, ItemColorItem.Color) &&
+								checkPermissionAccess("curses_color", getPlayerCharacter())
+							) {
+								if (ItemColorItem.Color) {
+									curse.Color = cloneDeep(ItemColorItem.Color);
+								} else {
+									delete curse.Color;
+								}
+								modStorageSync();
 							}
+						} else {
+							Callback(color);
+						}
+					};
+				}
+				return next(args);
+			});
+		} else {
+			// @ts-expect-error: Waiting for the R122 types here
+			hookFunction("ColorPickerReload", 0, (_args, _next) => {
+				// Shenanigens to get rid of the `never` types due to a lack of R122 `ColorPickerReload` declarations
+				const args = _args as [options?: null | ColorPickerInitOptions];
+				const next = _next as never as (arg: typeof args) => null | HTMLElement;
+
+				if (!ItemColorCharacter?.IsPlayer() || !ItemColorItem) {
+					return next(args);
+				}
+
+				const curse = ConditionsGetCondition("curses", ItemColorItem.Asset.Group.Name)?.data;
+				if (!curse) {
+					return next(args);
+				}
+
+				// Either propogate the player's color changes to the curse data or disable the color picker
+				const options = args[0] ??= {};
+				if (checkPermissionAccess("curses_color", getPlayerCharacter())) {
+					const originalExit = options.onExit;
+					options.onExit = (state, save, ...rest) => {
+						originalExit?.(state, save, ...rest);
+						if (!save) {
+							return;
+						}
+
+						// Interpret colors/opacities in their default state as "don't curse them"
+						let sync = false;
+						if (!CommonArraysEqual(state.colors, state.initialColors)) {
+							curse.Color = CommonArraysEqual(state.colors, state.defaultColors) ? undefined : cloneDeep(state.colors);
+							sync = true;
+						}
+						if (!CommonArraysEqual(state.opacity, state.initialOpacity)) {
+							(curse.Property ??= {}).Opacity = CommonArraysEqual(state.opacity, state.defaultOpacity) ? undefined : cloneDeep(state.opacity);
+							sync = true;
+						}
+						if (sync) {
 							modStorageSync();
 						}
-					} else {
-						Callback(color);
-					}
-				};
-			}
-			return next(args);
-		});
+					};
+				} else {
+					options.disabled = true;
+					options.heading = [
+						ElementCreate({ tag: "q", children: [ItemColorItem.Asset.Description] }),
+						" coloring disabled by BCX curse",
+					];
+				}
+				return next(args);
+			});
+		}
 
 		trackFunction("CharacterAppearanceGenderAllowed");
 	}


### PR DESCRIPTION
Xref (BondageProjects/Bondage-College#5870)[https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5870]

Adapts BCX to the R122 color picker DOMification changes, an adaptation that also involves a set of minor improvements:
* Opacity changes made in the color picker are now also propagated to the curse data
* Curse data updates are now delayed until the color picker is closed, rather than (potentially) updating them ever draw cycle or, equivalently-ish, every `input` event
* The color picker UI is now disabled if the player lacks permission to change their own cursed item color

Examples
----------

https://github.com/user-attachments/assets/c502a99a-1de4-47b0-abb4-22637e0e3836

