### PR TITLE
[FIX] Ensure that the color picker is only disabled for cursed items when the curse is actually active

### DIFF
--- a/src/modules/curses.ts
+++ b/src/modules/curses.ts
@@ -991,7 +991,8 @@ export class ModuleCurses extends BaseModule {
 					return next(args);
 				}
 
-				const curse = ConditionsGetCondition("curses", ItemColorItem.Asset.Group.Name)?.data;
+				const curseCondition = ConditionsGetCondition("curses", ItemColorItem.Asset.Group.Name);
+				const curse = curseCondition?.data;
 				if (!curse) {
 					return next(args);
 				}
@@ -1020,7 +1021,7 @@ export class ModuleCurses extends BaseModule {
 							modStorageSync();
 						}
 					};
-				} else {
+				} else if (curseCondition.active) {
 					options.disabled = true;
 					options.heading = [
 						ElementCreate({ tag: "q", children: [ItemColorItem.Asset.Description] }),


### PR DESCRIPTION
Follow up on https://github.com/Jomshir98/bondage-club-extended/pull/43

Aforementioned PR would disable the color picker in >= R122 if the player tries to alter the color of their cursed items but lack permission to do so (per their BCX settings). This followup fix a missing check to verify whether the relevant curse is actually active.