### PR TITLE
[FIX] Ensure that the curse crafted item logic treats `undefined` and absent as equivalent

### DIFF
--- a/src/modules/curses.ts
+++ b/src/modules/curses.ts
@@ -18,6 +18,7 @@ import { BCXGlobalEventSystem } from "../event";
 
 import cloneDeep from "lodash-es/cloneDeep";
 import isEqual from "lodash-es/isEqual";
+import { omitBy, isNil } from "lodash-es";
 import zod, { ZodType } from "zod";
 
 const CURSES_ANTILOOP_RESET_INTERVAL = 60_000;
@@ -1179,14 +1180,15 @@ export class ModuleCurses extends BaseModule {
 		}
 
 		// Crafted properties are always cursed
-		const validatedCurseCraft = ValidationVerifyCraftData(curse.Craft, asset).result;
-		if (!isEqual(ValidationVerifyCraftData(currentItem.Craft, currentItem.Asset).result, validatedCurseCraft)) {
-			if (validatedCurseCraft === undefined) {
+		const craftOld = ValidationVerifyCraftData(curse.Craft, asset).result;
+		const craftNew = ValidationVerifyCraftData(currentItem.Craft, currentItem.Asset).result;
+		if (!isEqual(omitBy(craftOld, isNil), omitBy(craftNew, isNil))) {
+			if (craftOld === undefined) {
 				delete currentItem.Craft;
 			} else {
 				currentItem.Craft = {
 					...(isObject(currentItem.Craft) ? currentItem.Craft : {}),
-					...validatedCurseCraft,
+					...craftOld,
 				};
 			}
 			if (!changeType) changeType = "update";


### PR DESCRIPTION
Fixes a comparison between crafted item data akin to the `{ ... }` / `{ ..., Type: undefined }` pair triggering a "cursed item has woken up loop" due to not treating the `undefined`- and absent property as equivalent.