### PR TITLE
[FEATURE] Add rules blocking self access to curses/rules placed by others

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -260,6 +260,8 @@ type BCX_Rule =
 	| "block_mainhall_maidrescue"
 	| "block_action"
 	| "block_BCX_permissions"
+	| "block_curses_self_by_others"
+	| "block_rules_self_by_others"
 	| "block_room_admin_UI"
 	| "block_using_ggts"
 	| "block_club_slave_work"

--- a/src/gui/conditions_edit_base.ts
+++ b/src/gui/conditions_edit_base.ts
@@ -6,7 +6,7 @@ import { AccessLevel } from "../modules/authority";
 import { ConditionsLimit } from "../constants";
 import { capitalizeFirstLetter, formatTimeInterval } from "../utils";
 import { GuiMemberSelect } from "./member_select";
-import { ConditionsEvaluateRequirements } from "../modules/conditions";
+import { ConditionsConditionBlockedByRule, ConditionsEvaluateRequirements, ConditionsGetCondition } from "../modules/conditions";
 import { icon_star } from "../resources";
 import { DrawQueryErrorMessage } from "../modules/messaging";
 
@@ -160,6 +160,14 @@ export abstract class GuiConditionEdit<CAT extends ConditionsCategories> extends
 	protected checkAccess(): boolean {
 		if (!this.conditionCategoryData)
 			return false;
+
+		if (this.character.MemberNumber === Player.MemberNumber) {
+			// Get self's internal condition data to ensure we aren't relying on the *_view_originator authority (as public data does).
+			const internalData = ConditionsGetCondition(this.conditionCategory, this.conditionName);
+			if (internalData && ConditionsConditionBlockedByRule(this.conditionCategory, internalData, this.character))
+				return false;
+		}
+
 		const limit = this.conditionCategoryData.limits[this.conditionName] ?? ConditionsLimit.normal;
 		return [this.conditionCategoryData.access_normal, this.conditionCategoryData.access_limited, false][limit];
 	}

--- a/src/gui/conditions_view_curses.ts
+++ b/src/gui/conditions_view_curses.ts
@@ -1,4 +1,5 @@
 import { ChatroomCharacter } from "../characters";
+import { ConditionsCategoryInfluencedByRule } from "../modules/conditions";
 import { curseAllowItemCurseProperty } from "../modules/curses";
 import { setSubscreen } from "../modules/gui";
 import { DrawImageEx, getVisibleGroupName, showHelp } from "../utilsClub";
@@ -29,7 +30,7 @@ export class GuiConditionViewCurses extends GuiConditionView<"curses", CurseEntr
 		DrawButton(120, 820, 250, 90, "Add new curse", "White", "",
 			"Place new curses on body, items or clothes");
 
-		const access = this.conditionCategoryData.access_normal || this.conditionCategoryData.access_limited;
+		const access = (this.conditionCategoryData.access_normal || this.conditionCategoryData.access_limited) && !ConditionsCategoryInfluencedByRule(this.conditionCategory, this.character);
 		DrawButton(400, 820, 250, 90, "Lift all curses", access ? "White" : "#ddd", "",
 			access ? "Remove all curses on body, items or clothes" : "You have no permission to use this", !access);
 
@@ -49,7 +50,7 @@ export class GuiConditionViewCurses extends GuiConditionView<"curses", CurseEntr
 			return true;
 		}
 
-		const access = this.conditionCategoryData.access_normal || this.conditionCategoryData.access_limited;
+		const access = (this.conditionCategoryData.access_normal || this.conditionCategoryData.access_limited) && !ConditionsCategoryInfluencedByRule(this.conditionCategory, this.character);
 		if (access && MouseIn(400, 820, 250, 90)) {
 			this.character.curseLiftAll();
 			return true;

--- a/src/modules/rules.ts
+++ b/src/modules/rules.ts
@@ -19,7 +19,7 @@ import { ChatRoomActionMessage, ChatRoomSendLocal, DrawImageEx, getCharacterName
 import { BaseModule } from "./_BaseModule";
 import { AccessLevel, registerPermission } from "./authority";
 import { Command_fixExclamationMark, COMMAND_GENERIC_ERROR, Command_pickAutocomplete, registerWhisperCommand } from "./commands";
-import { ConditionsAutocompleteSubcommand, ConditionsCheckAccess, ConditionsGetCategoryPublicData, ConditionsGetCondition, ConditionsIsConditionInEffect, ConditionsRegisterCategory, ConditionsRemoveCondition, ConditionsRunSubcommand, ConditionsSetCondition, ConditionsSubcommand, ConditionsSubcommands } from "./conditions";
+import { ConditionsAutocompleteSubcommand, ConditionsConditionBlockedByRule, ConditionsCheckAccess, ConditionsGetCategoryPublicData, ConditionsGetCondition, ConditionsIsConditionInEffect, ConditionsRegisterCategory, ConditionsRemoveCondition, ConditionsRunSubcommand, ConditionsSetCondition, ConditionsSubcommand, ConditionsSubcommands } from "./conditions";
 import { getCurrentSubscreen, setSubscreen } from "./gui";
 import { LogEntryType, logMessage } from "./log";
 import { queryHandlers } from "./messaging";
@@ -762,6 +762,10 @@ export function RulesDelete(rule: BCX_Rule, character: ChatroomCharacter | null)
 		return false;
 
 	if (character && !ConditionsCheckAccess("rules", rule, character))
+		return false;
+
+	const data = ConditionsGetCondition("rules", rule);
+	if (data && ConditionsConditionBlockedByRule("rules", data, character))
 		return false;
 
 	const display = RulesGetDisplayDefinition(rule);

--- a/src/rules/bc_blocks.ts
+++ b/src/rules/bc_blocks.ts
@@ -983,6 +983,28 @@ export function initRules_bc_blocks() {
 		// Implemented externally
 	});
 
+	registerRule("block_curses_self_by_others", {
+		name: "Prevent accessing curses by others",
+		loggable: false,
+		type: RuleType.Block,
+		shortDescription: "PLAYER_NAME accessing curses placed on herself by others",
+		longDescription: "This rule forbids PLAYER_NAME from accessing (or removing) any curses that were placed on her by other BCX users. This additionally blocks bulk actions and editing the global config to prevent bypassing this rule. PLAYER_NAME can still access (and remove) curses she herself placed. This rule does not affect PLAYER_NAME's permissions to use another users' BCX.",
+		keywords: ["limiting", "preventing", "controling", "accessing", "self", "rights"],
+		defaultLimit: ConditionsLimit.blocked,
+		// Implemented externally
+	});
+
+	registerRule("block_rules_self_by_others", {
+		name: "Prevent accessing rules by others",
+		loggable: false,
+		type: RuleType.Block,
+		shortDescription: "PLAYER_NAME accessing rules placed on herself by others",
+		longDescription: "This rule forbids PLAYER_NAME from accessing (or removing) any rules that were placed on her by other BCX users. This additionally blocks bulk actions and editing the global config to prevent bypassing this rule. PLAYER_NAME can still access (and remove) rules she herself placed. This rule does not affect PLAYER_NAME's permissions to use another users' BCX.",
+		keywords: ["limiting", "preventing", "controling", "accessing", "self", "rights"],
+		defaultLimit: ConditionsLimit.blocked,
+		// Implemented externally
+	});
+
 	registerRule("block_room_admin_UI", {
 		name: "Forbid looking at room admin UI",
 		type: RuleType.Block,


### PR DESCRIPTION
## Functionality
As per the title, implements `block_curses_self_by_others` and `block_rules_self_by_others`. Respectively, they prevent the player from accessing any curse or rule placed on them by other players, only allowing access to curses/rules that they've placed themselves.

To prevent bypassing this rule, it also additionally blocks the player from utilizing bulk actions ("lift all" & co.) and modifying the global config for the respective affected category.

## Implementation
In respect to the decision to block bulk actions and the global config, it *was* considered to rework these buttons to only function on curses/rules the user has access to, however this was deemed to be out of scope for this PR, as the aforementioned behaviour follows the established standard (see permissions checks for _normal and _limited).

In terms of the technical implementation itself, while tested & functional, the methodology used to verify access in `conditions_view_*` and `conditions_edit_*` are less than optimal. In each of these cases, the code runs an explicit check to verify whether the viewed/edited character is the player themselves, before then retrieving internal condition data through `ConditionsGetCondition`. It is done this way due to the inherent limitation of `ConditionsCategoryPublicData`, which is usually provided to these classes, in that `ConditionsCategoryPublicData`'s `addedBy` property cannot be consistently relied upon (it depends on the `*_view_originator` authority). While not optimal, this seemed to be the most straightforward route to achieve such functionality without a rewrite of the `conditions_view_*` and `conditions_edit_*` classes (to have inherent access to such data, flags denoting a self edit, or similar). If there are any suggestions for improving this implementation, I'm all ears.

## Ethical & Risk Considerations
### Default Permission
Following after `block_BCX_permissions` and due to the logical risk of blocking the player from accessing a potentially restrictive portion of their BCX configuration, this rule is BLOCKED/DISABLED by default, requiring a player to manually enable it.

### Self Access
While the player *does* have access to place these rules on themselves, there is no risk associated, as they do not meet the requirement for the block to activate (not placed by another player), and as thus, they will always be able to remove these rules if placed on/by themselves.

### Failsafes
These rules do not have any explicit handling of edge cases (unlike `block_BCX_permissions`'s lowest access), and from a brief logical rundown of the potential impacts of these rules and their restrictiveness, I do not currently believe they should be necessary. A worst-case-scenario for this rule is it being placed on a player (by another player, so they are not able to remove it themselves, by the rule's own functionality), then all players with the authority to manage rules losing access to the player's BCX. This worst-case should be manageable by adding new owners/mistresses, adjusting the lowest permission level to access rules, or similar -- the ability to do so (anti-lockout) is already handled through BCX's inherent safeguards outside of this rule. As the rule itself does not prevent access to such mechanisms, no such risk should exist (and safety would meet the established baseline by other similar rules).

---

## Related PRs

- #50 ensures that the originator/`addedBy` field is properly present for batch curses, and is necessary for full & reliable functionality