### PR TITLE
[CHORE] Backfill CHANGELOG.md from `v1.1.7` to `v1.1.10`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,35 @@ On the bright side we also aren't simply going away. There is a certain secret p
 
 # BCX Changelog
 
+## 1.1.10
+
+This update fixes the curses group UI and a curse application loop caused by a change in BC R122.
+
+## 1.1.9
+
+This update changes the following:
+- Fix a conflict with UBC's chat lobby customizations
+- Fix the "Mandatory words" rule not triggering
+- Implement `speech_replace_spoken_words`/"Replace spoken words" rule
+- Fix a crash when being summoned out of a room
+- Properly hide the new Allowed Interaction selector of BC when opening BCX
+- Ensure that the color picker is only disabled for cursed items when the curse is actually active (#46)
+
+## 1.1.8
+
+This update changes the following:
+- Preliminary compatibility with the color picker changes coming in R122
+- Updating the `block_entering_rooms` to work with the new chat lobby interface
+- Closing a speech restriction bypass using the `/whisper` command, ensuring those messages also get restricted
+- Fixing a low-priority hook in the admin screen allowing other mods be called even though at that point the whole screen might be custom; fixes an UBC UI element hovering around in the template & theme customization subscreens
+
+## 1.1.7
+
+This update adds the following:
+- Several new APIs that other mod developers can use to better integrate with BCX. See: [`src/bcxExternalInterface.d.ts`](https://github.com/Jomshir98/bondage-club-extended/blob/master/src/bcxExternalInterface.d.ts)
+- A new utility chat command `.debugreport` to easily generate a manual debug report for debugging other problems than crashes
+- Support for Asia servers in the UserScript loader
+
 ## 1.1.6
 
 This update fixes some missing background images that were added to BC.


### PR DESCRIPTION
This PR backfills CHANGELOG.md (which has been out of date since `v1.1.6`) with the content from `#bcx-updates` on Discord