### PR TITLE
[ADD] Rules blocking self-tying and freeing others

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -251,6 +251,8 @@ type BCX_Rule =
 	| "block_entering_rooms"
 	| "block_leaving_room"
 	| "block_freeing_self"
+	| "block_freeing_others"
+	| "block_tying_self"
 	| "block_tying_others"
 	| "block_blacklisting"
 	| "block_whitelisting"
@@ -361,6 +363,9 @@ type RuleCustomData = {
 		minimumRole: import("./modules/authority").AccessLevel;
 	};
 	block_freeing_self: {
+		allowEasyItemsToggle: boolean;
+	};
+	block_freeing_others: {
 		allowEasyItemsToggle: boolean;
 	};
 	block_tying_others: {


### PR DESCRIPTION
Closes #54.

## Functionality
As per the title, implements `block_tying_self` and `block_freeing_others` mirroring `block_tying_others` and `block_freeing_self` respectively.

## Implementation
Implementations are copied and edited from their source paired rule (`block_tying_others` -> `block_tying_self` and `block_freeing_self` -> `block_freeing_others`).

### Deprecated Code
The new rules use `C.IsPlayer()` instead of `C.ID === 0` checks, as this is now best practice. Old rules have not been ported to minimize the scope of this PR.

### Duplicate Code
As mentioned, code for these new rules are copied directly from the similar self/other rules and as a result, duplicate code is created. This appears to be the existing practice for such self/other paired rules, so it has been left as-is instead of creating a function (or similar).

### Known Issues
The visual disabling functionality of `block_tying_other` (and now, by extension, `block_tying_self`), which is intended to grey out buttons from the application/selection screen does not function due to the DOMification of that particular screen (it no longer uses `AppearanceGetPreviewImageColor`).

A brief attempt was made to fix this functionality, though I eventually deemed it better fit for a separate PR. The non-functional code is committed as-is for easier identification and fixing in the future (though could also be replaced with a TODO).