### PR TITLE
[CHORE] Adapt to BC R131 changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@types/jest": "^30.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.21.0",
 		"@typescript-eslint/parser": "^8.21.0",
-		"bc-stubs": "^130.0.0",
+		"bc-stubs": "^131.0.0",
 		"buffer": "^6.0.3",
 		"clean-webpack-plugin": "^4.0.0",
 		"copy-webpack-plugin": "^14.0.0",

--- a/src/gui/wardrobe_extended.ts
+++ b/src/gui/wardrobe_extended.ts
@@ -883,10 +883,16 @@ function checkImportItemNoChange(group: AssetGroupName, a: ItemBundle[], b: Item
 		return true;
 	if (item1 === undefined || item2 === undefined)
 		return false;
+
+	const asset1 = AssetGet("Female3DCG", group, item1.Name);
+	const asset2 = AssetGet("Female3DCG", group, item2.Name);
+	if (!asset1 || !asset2) {
+		return false;
+	}
 	return (
 		item1.Group === item2.Group &&
 		item1.Name === item2.Name &&
-		itemColorsEquals(item1.Color, item2.Color) &&
+		itemColorsEquals(item1.Color, item2.Color, asset1, asset2) &&
 		(item1.Difficulty ?? 0) === (item2.Difficulty ?? 0) &&
 		isEqual(
 			item1.Property ?? {},

--- a/src/modules/clubUtils.ts
+++ b/src/modules/clubUtils.ts
@@ -24,7 +24,7 @@ export function InvisibilityEarbuds() {
 		Player.Appearance = Player.Appearance.filter(A => A.Asset.Group.Name !== "ItemEars");
 		Player.Appearance.push({
 			Asset: asset,
-			Color: "Default",
+			Color: [...asset.DefaultColor],
 			Difficulty: -100,
 			Property: {
 				Type: "Light",

--- a/src/modules/curses.ts
+++ b/src/modules/curses.ts
@@ -94,7 +94,7 @@ function curseCreateCurseItemInfo(item: Item): CursedItemInfo {
 		Name: item.Asset.Name,
 		curseProperty: false,
 		Difficulty: item.Difficulty || undefined,
-		Color: (item.Color && item.Color !== "Default") ? cloneDeep(item.Color) : undefined,
+		Color: !ItemColorIsDefault(item) ? cloneDeep(item.Color) : undefined,
 		Property: curseMakeSavedProperty(item.Property),
 		Craft: ValidationVerifyCraftData(item.Craft, item.Asset).result,
 	};
@@ -935,11 +935,11 @@ export class ModuleCurses extends BaseModule {
 				const character = getChatroomCharacter(params.sourceMemberNumber);
 				if (curse &&
 					result.item.Asset.Name === curse.Name &&
-					!itemColorsEquals(curse.Color, result.item.Color) &&
+					!itemColorsEquals(curse.Color, result.item.Color, result.item.Asset, result.item.Asset) &&
 					character &&
 					checkPermissionAccess("curses_color", character)
 				) {
-					if (result.item.Color && result.item.Color !== "Default") {
+					if (!ItemColorIsDefault(result.item)) {
 						curse.Color = cloneDeep(result.item.Color);
 					} else {
 						delete curse.Color;
@@ -1089,13 +1089,13 @@ export class ModuleCurses extends BaseModule {
 		}
 
 		if (!currentItem) {
-			currentItem = {
-				Asset: asset,
-				Color: curse.Color != null ? cloneDeep(curse.Color) : "Default",
-				Property: curse.Property != null ? cloneDeep(curse.Property) : {},
-				Craft: ValidationVerifyCraftData(curse.Craft, asset).result,
-				Difficulty: curse.Difficulty != null ? curse.Difficulty : 0,
-			};
+			currentItem = AppearanceItem.fromAsset(asset, {
+				color: curse.Color,
+				property: curse.Property,
+				craft: ValidationVerifyCraftData(curse.Craft, asset).result,
+				difficulty: curse.Difficulty,
+			});
+
 			// re-init extended properties to avoid problems in recent BC versions
 			ExtendedItemInit(Player, currentItem, false, false);
 			curse.Property = curseCreateCurseItemInfo(currentItem).Property;
@@ -1158,12 +1158,9 @@ export class ModuleCurses extends BaseModule {
 			if (!changeType) changeType = "update";
 		}
 
-		if (!itemColorsEquals(curse.Color, currentItem.Color)) {
-			if (curse.Color === undefined || curse.Color === "Default") {
-				delete currentItem.Color;
-			} else {
-				currentItem.Color = cloneDeep(curse.Color);
-			}
+		const curseColor = curse.Color ? ServerParseColor(currentItem.Asset, curse.Color, currentItem.Asset.Group.ColorSchema) : [...currentItem.Asset.DefaultColor];
+		if (!itemColorsEquals(curseColor, currentItem.Color, currentItem.Asset, currentItem.Asset)) {
+			currentItem.Color = cloneDeep(curseColor);
 			if (!changeType) changeType = "color";
 		}
 

--- a/src/modules/custom.ts
+++ b/src/modules/custom.ts
@@ -32,7 +32,7 @@ export class ModuleCustom extends BaseModule {
 				const c = InventoryGet(C.Character, "ItemVulva");
 				const a = AssetGet(C.Character.AssetFamily, "ItemVulva", "DoubleEndDildo");
 				const f = AssetGet(C.Character.AssetFamily, "ItemVulva", "FuturisticVibrator");
-				if (c && c.Asset === a && c.Color === "#A7806F" && f) {
+				if (c && c.Asset === a && c.Color.includes("#A7806F") && f) {
 					InventoryRemove(C.Character, "ItemVulva");
 					C.Character.Appearance.push({
 						Asset: f,

--- a/src/modules/wardrobe.ts
+++ b/src/modules/wardrobe.ts
@@ -56,7 +56,7 @@ export function itemMergeProperties(sourceProperty: Partial<ItemProperties> | un
 }: {
 	includeNoncursableProperties?: boolean;
 	lockAssignMemberNumber?: number;
-} = {}): Partial<ItemProperties> | undefined {
+} = {}): Partial<ItemProperties> {
 
 	const itemProperty = cloneDeep(sourceProperty ?? {});
 	targetProperty = cloneDeep(targetProperty ?? {});
@@ -109,9 +109,6 @@ export function itemMergeProperties(sourceProperty: Partial<ItemProperties> | un
 		itemProperty.Effect = curseEffects.concat(itemIgnoredEffects);
 	}
 
-	if (Object.keys(targetProperty).length === 0) {
-		return undefined;
-	}
 	return itemProperty;
 }
 
@@ -119,7 +116,7 @@ export function WardrobeImportCheckChangesLockedItem(C: Character, data: ItemBun
 	if (C.Appearance.some(a => isBind(a) && a.Property?.Effect?.includes("Lock"))) {
 		// Looks for all locked items and items blocked by locked items and checks, that none of those change by the import
 		// First find which groups should match
-		const matchedGroups: Set<string> = new Set();
+		const matchedGroups: Set<AssetGroupName> = new Set();
 		const test = (item: Item) => {
 			if (isBind(item)) {
 				// For each blocked group
@@ -144,6 +141,7 @@ export function WardrobeImportCheckChangesLockedItem(C: Character, data: ItemBun
 		for (const testedGroup of matchedGroups) {
 			const currentItem = C.Appearance.find(a => a.Asset.Group.Name === testedGroup);
 			const newItem = data.find(b => b.Group === testedGroup);
+			const newAsset = newItem ? AssetGet("Female3DCG", testedGroup, newItem.Name) : null;
 			if (!currentItem) {
 				if (newItem) {
 					return true;
@@ -155,8 +153,9 @@ export function WardrobeImportCheckChangesLockedItem(C: Character, data: ItemBun
 				continue;
 			if (
 				!newItem ||
+                !newAsset ||
 				currentItem.Asset.Name !== newItem.Name ||
-				!itemColorsEquals(currentItem.Color, newItem.Color) ||
+				!itemColorsEquals(currentItem.Color, newItem.Color, currentItem.Asset, newAsset) ||
 				!isEqual(currentItem.Property ?? {}, itemMergeProperties(currentItem.Property, newItem.Property, {
 					includeNoncursableProperties: true,
 					lockAssignMemberNumber: Player.MemberNumber,
@@ -321,14 +320,16 @@ export function j_WardrobeImportSelectionClothes(data: string | ItemBundle[], in
 	// Check if everything (except ignored properties) matches
 	let fullMatch = includeBinds;
 	if (includeBinds) {
-		for (const group of arrayUnique(C.Appearance.filter(Allow).map<string>(item => item.Asset.Group.Name).concat(data.map(item => item.Group)))) {
+		for (const group of arrayUnique(C.Appearance.filter(Allow).map<AssetGroupName>(item => item.Asset.Group.Name).concat(data.map(item => item.Group)))) {
 			const wornItem = C.Appearance.find(item => item.Asset.Group.Name === group);
 			const bundleItem = data.find(item => item.Group === group);
+			const bundleAsset = bundleItem ? AssetGet("Female3DCG", group, bundleItem.Name) : null;
 			if (
 				!wornItem ||
 				!bundleItem ||
+                !bundleAsset ||
 				wornItem.Asset.Name !== bundleItem.Name ||
-				!itemColorsEquals(wornItem.Color, bundleItem.Color) ||
+				!itemColorsEquals(wornItem.Color, bundleItem.Color, wornItem.Asset, bundleAsset) ||
 				!isEqual(curseMakeSavedProperty(wornItem.Property), curseMakeSavedProperty(bundleItem.Property))
 			) {
 				fullMatch = false;

--- a/src/utilsClub.ts
+++ b/src/utilsClub.ts
@@ -336,20 +336,18 @@ export function getCharacterNickname(memberNumber: number, defaultText: string |
 	return getCharacterName(memberNumber, defaultText);
 }
 
-export function itemColorsEquals(color1: null | undefined | string | string[], color2: null | undefined | string | string[]): boolean {
-	if (color1 == null) {
-		color1 = "Default";
-	} else if (Array.isArray(color1) && color1.length === 1) {
-		color1 = color1[0];
-	}
-
-	if (color2 == null) {
-		color2 = "Default";
-	} else if (Array.isArray(color2) && color2.length === 1) {
-		color2 = color2[0];
-	}
-
-	return (!Array.isArray(color1) || !Array.isArray(color2)) ? color1 === color2 : CommonArraysEqual(color1, color2);
+export function itemColorsEquals(
+	color1: null | undefined | ItemColor,
+	color2: null | undefined | ItemColor,
+	asset1: Asset,
+	asset2: Asset
+): boolean {
+	color1 ??= [...asset1.DefaultColor];
+	color2 ??= [...asset2.DefaultColor];
+	return CommonArraysEqual(
+		ServerParseColor(asset1, color1, asset1.Group.ColorSchema),
+		ServerParseColor(asset2, color2, asset2.Group.ColorSchema)
+	);
 }
 
 export function showHelp(helpText: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,10 +2147,10 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
-bc-stubs@^130.0.0:
-  version "130.0.0"
-  resolved "https://registry.yarnpkg.com/bc-stubs/-/bc-stubs-130.0.0.tgz#4e288c818329ae29ce6b7167e27d237bcf9ea91d"
-  integrity sha512-WXbJz9nn6PraZReYPYrDBao5mF8Jtn4xo6hwagjyYeuwdH+e57WwMB8g20pKgTBcbzv2tt/OHgrJcrYfZR2lIA==
+bc-stubs@^131.0.0:
+  version "131.0.0"
+  resolved "https://registry.yarnpkg.com/bc-stubs/-/bc-stubs-131.0.0.tgz#94b4fbd7c056cfe87d9724f6002c3124ad705cc7"
+  integrity sha512-uGEX42Qims1iWgAp3Tc2EInsYtmbuw/KUk/kzx+0HBdxoW+6oj5ED84vlefxe9ko7yy8haOc/AIr1gAYg7Dvbw==
   dependencies:
     "@total-typescript/ts-reset" "^0.6.1"
     socket.io-client "4.6.1"


### PR DESCRIPTION
Bumps bc-stubs to v131 and adapts to the `Item` changes of R131: most of its properties are now mandatory and `Item.Color` specifically is now always an array. Among others, this includes improvements in the comparison logic between color arrays, color strings and undefined colors (_i.e._ implicit defaults), as BCX's `CursedItemInfo.Color` format still accepts all three options.