### PR TITLE
[FIX] Ensure that conditional requirements are checked before a curse disables the color picker

### DIFF
--- a/src/modules/curses.ts
+++ b/src/modules/curses.ts
@@ -10,7 +10,23 @@ import { moduleIsEnabled } from "./presets";
 import { ModuleCategory, Preset, ConditionsLimit } from "../constants";
 import { callOriginal, hookFunction, removeAllHooksByModule, trackFunction } from "../patching";
 import { Command_fixExclamationMark, COMMAND_GENERIC_ERROR, Command_pickAutocomplete, Command_selectGroup, Command_selectGroupAutocomplete, registerWhisperCommand } from "./commands";
-import { ConditionsAutocompleteSubcommand, ConditionsConditionBlockedByRule, ConditionsCheckAccess, ConditionsGetCategoryData, ConditionsGetCategoryPublicData, ConditionsGetCondition, ConditionsRegisterCategory, ConditionsRemoveCondition, ConditionsRunSubcommand, ConditionsSetCondition, ConditionsSubcommand, ConditionsSubcommands, ConditionsUpdate, ConditionsCategoryInfluencedByRule } from "./conditions";
+import {
+	ConditionsIsConditionInEffect,
+	ConditionsAutocompleteSubcommand,
+	ConditionsConditionBlockedByRule,
+	ConditionsCheckAccess,
+	ConditionsGetCategoryData,
+	ConditionsGetCategoryPublicData,
+	ConditionsGetCondition,
+	ConditionsRegisterCategory,
+	ConditionsRemoveCondition,
+	ConditionsRunSubcommand,
+	ConditionsSetCondition,
+	ConditionsSubcommand,
+	ConditionsSubcommands,
+	ConditionsUpdate,
+	ConditionsCategoryInfluencedByRule,
+} from "./conditions";
 import { cursedChange, CURSES_TRIGGER_TEXTS, CURSES_TRIGGER_TEXTS_BATCH } from "./cursesConstants";
 import { BCX_setInterval } from "../BCXContext";
 import { ValidationVerifyCraftData } from "./wardrobe";
@@ -987,7 +1003,7 @@ export class ModuleCurses extends BaseModule {
 						modStorageSync();
 					}
 				};
-			} else if (curseCondition.active) {
+			} else if (ConditionsIsConditionInEffect("curses", ItemColorItem.Asset.Group.Name)) {
 				options.disabled = true;
 				options.heading = [
 					ElementCreate({ tag: "q", children: [ItemColorItem.Asset.Description] }),


### PR DESCRIPTION
Curses have the option to only be triggered when certain conditions are met (_e.g._ when certain characters are in a room). Previously, these conditional requirements weren't checked when determining whether the color picker UI should be disabled due to a lack of appropriate cursed item permissions.